### PR TITLE
Add os-string feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,4 @@ exclude = [
 default = ["std"]
 std = []
 thread-safe = ["std"]
+os-string = ["std"]

--- a/src/build.rs
+++ b/src/build.rs
@@ -7,6 +7,7 @@ use core::ops::Deref;
 
 use crate::stmt::{Stmt, StmtRef};
 use crate::util::{AddOnlyVec, Indented, RefCounted};
+use crate::{MaybeOs, MaybeOsDisplay};
 use crate::{Rule, RuleVariables, Variable, Variables};
 
 /// A build edge, as defined by the `build` keyword
@@ -36,32 +37,32 @@ pub struct Build {
     pub rule: RefCounted<String>,
 
     /// The list of outputs, as defined by `build <outputs>:`
-    pub outputs: AddOnlyVec<String>,
+    pub outputs: AddOnlyVec<MaybeOs!(String)>,
 
     /// The list of implicit outputs.
     ///
     /// See <https://ninja-build.org/manual.html#ref_outputs>
-    pub implicit_outputs: AddOnlyVec<String>,
+    pub implicit_outputs: AddOnlyVec<MaybeOs!(String)>,
 
     /// The list of dependencies (inputs).
     ///
     /// See <https://ninja-build.org/manual.html#ref_dependencies>
-    pub dependencies: AddOnlyVec<String>,
+    pub dependencies: AddOnlyVec<MaybeOs!(String)>,
 
     /// The list of implicit dependencies (inputs).
     ///
     /// See <https://ninja-build.org/manual.html#ref_dependencies>
-    pub implicit_dependencies: AddOnlyVec<String>,
+    pub implicit_dependencies: AddOnlyVec<MaybeOs!(String)>,
 
     /// The list of order-only dependencies (inputs).
     ///
     /// See <https://ninja-build.org/manual.html#ref_dependencies>
-    pub order_only_dependencies: AddOnlyVec<String>,
+    pub order_only_dependencies: AddOnlyVec<MaybeOs!(String)>,
 
     /// The list of validations.
     ///
     /// See <https://ninja-build.org/manual.html#validations>
-    pub validations: AddOnlyVec<String>,
+    pub validations: AddOnlyVec<MaybeOs!(String)>,
 
     /// The list of variables, as an indented block
     pub variables: AddOnlyVec<Variable>,
@@ -92,7 +93,7 @@ pub trait BuildVariables: Variables {
     #[inline]
     fn dyndep<SDyndep>(self, dyndep: SDyndep) -> Self
     where
-        SDyndep: AsRef<str>,
+        SDyndep: AsRef<MaybeOs!(str)>,
     {
         self.variable("dyndep", dyndep)
     }
@@ -116,7 +117,7 @@ pub trait BuildVariables: Variables {
     fn with<SInputIter, SInput>(self, inputs: SInputIter) -> Self
     where
         SInputIter: IntoIterator<Item = SInput>,
-        SInput: AsRef<str>,
+        SInput: AsRef<MaybeOs!(str)>,
     {
         self.as_build()
             .dependencies
@@ -146,7 +147,7 @@ pub trait BuildVariables: Variables {
     fn with_implicit<SInputIter, SInput>(self, inputs: SInputIter) -> Self
     where
         SInputIter: IntoIterator<Item = SInput>,
-        SInput: AsRef<str>,
+        SInput: AsRef<MaybeOs!(str)>,
     {
         self.as_build()
             .implicit_dependencies
@@ -177,7 +178,7 @@ pub trait BuildVariables: Variables {
     fn with_order_only<SInputIter, SInput>(self, inputs: SInputIter) -> Self
     where
         SInputIter: IntoIterator<Item = SInput>,
-        SInput: AsRef<str>,
+        SInput: AsRef<MaybeOs!(str)>,
     {
         self.as_build()
             .order_only_dependencies
@@ -209,7 +210,7 @@ pub trait BuildVariables: Variables {
     fn validations<SValidationIter, SValidation>(self, validations: SValidationIter) -> Self
     where
         SValidationIter: IntoIterator<Item = SValidation>,
-        SValidation: AsRef<str>,
+        SValidation: AsRef<MaybeOs!(str)>,
     {
         self.as_build()
             .validations
@@ -242,7 +243,7 @@ pub trait BuildVariables: Variables {
     fn output_implicit<SOutputIter, SOutput>(self, outputs: SOutputIter) -> Self
     where
         SOutputIter: IntoIterator<Item = SOutput>,
-        SOutput: AsRef<str>,
+        SOutput: AsRef<MaybeOs!(str)>,
     {
         self.as_build()
             .implicit_outputs
@@ -277,7 +278,7 @@ impl Build {
     pub fn new<SOutputIter, SOutput>(rule: &Rule, outputs: SOutputIter) -> Self
     where
         SOutputIter: IntoIterator<Item = SOutput>,
-        SOutput: AsRef<str>,
+        SOutput: AsRef<MaybeOs!(str)>,
     {
         let self_outputs = AddOnlyVec::new();
         self_outputs.extend(outputs.into_iter().map(|s| s.as_ref().to_owned()));
@@ -328,27 +329,27 @@ impl Display for Build {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         write!(f, "build")?;
         for output in self.outputs.inner().iter() {
-            write!(f, " {}", output)?;
+            write!(f, " {}", MaybeOsDisplay!(output))?;
         }
         {
             let implicit_outputs = self.implicit_outputs.inner();
             if !implicit_outputs.is_empty() {
                 write!(f, " |")?;
                 for output in implicit_outputs.iter() {
-                    write!(f, " {}", output)?;
+                    write!(f, " {}", MaybeOsDisplay!(output))?;
                 }
             }
         }
         write!(f, ": {}", self.rule)?;
         for input in self.dependencies.inner().iter() {
-            write!(f, " {}", input)?;
+            write!(f, " {}", MaybeOsDisplay!(input))?;
         }
         {
             let implicit_dependencies = self.implicit_dependencies.inner();
             if !implicit_dependencies.is_empty() {
                 write!(f, " |")?;
                 for input in implicit_dependencies.iter() {
-                    write!(f, " {}", input)?;
+                    write!(f, " {}", MaybeOsDisplay!(input))?;
                 }
             }
         }
@@ -357,7 +358,7 @@ impl Display for Build {
             if !order_only_dependencies.is_empty() {
                 write!(f, " ||")?;
                 for input in order_only_dependencies.iter() {
-                    write!(f, " {}", input)?;
+                    write!(f, " {}", MaybeOsDisplay!(input))?;
                 }
             }
         }
@@ -366,7 +367,7 @@ impl Display for Build {
             if !validations.is_empty() {
                 write!(f, " |@")?;
                 for input in validations.iter() {
-                    write!(f, " {}", input)?;
+                    write!(f, " {}", MaybeOsDisplay!(input))?;
                 }
             }
         }

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -1,0 +1,42 @@
+#[macro_export]
+#[doc(hidden)]
+#[cfg(feature = "os-string")]
+macro_rules! MaybeOs {
+    (str) => {
+        std::ffi::OsStr
+    };
+    (String) => {
+        std::ffi::OsString
+    };
+    ($value:expr) => {
+        std::ffi::OsString::from(AsRef::<str>::as_ref($value))
+    };
+}
+
+#[macro_export]
+#[doc(hidden)]
+#[cfg(not(feature = "os-string"))]
+macro_rules! MaybeOs {
+    (str) => {
+        str
+    };
+    (String) => {
+        String
+    };
+    ($value:expr) => {
+        $value
+    };
+}
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! MaybeOsDisplay {
+    ($value:expr) => {{
+        let maybe_os_display_internal = $value;
+
+        #[cfg(feature = "os-string")]
+        let maybe_os_display_internal = maybe_os_display_internal.to_string_lossy();
+
+        maybe_os_display_internal
+    }};
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,6 +185,8 @@ pub mod stmt;
 pub mod util;
 pub mod variable;
 
+mod internal;
+
 // Re-exports
 pub use build::{Build, BuildRef, BuildVariables};
 pub use ninja::Ninja;

--- a/src/ninja.rs
+++ b/src/ninja.rs
@@ -6,7 +6,7 @@ use core::fmt::{Display, Formatter, Result};
 
 use crate::stmt::{Stmt, StmtRef};
 use crate::util::{AddOnlyVec, RefCounted};
-use crate::{Build, BuildRef, Pool, PoolRef, Rule, RuleRef, Variable};
+use crate::{Build, BuildRef, MaybeOs, MaybeOsDisplay, Pool, PoolRef, Rule, RuleRef, Variable};
 
 /// The main entry point for writing a ninja file.
 ///
@@ -81,7 +81,7 @@ impl Ninja {
     pub fn phony<SOutputIter, SOutput>(&self, outputs: SOutputIter) -> BuildRef
     where
         SOutputIter: IntoIterator<Item = SOutput>,
-        SOutput: AsRef<str>,
+        SOutput: AsRef<MaybeOs!(str)>,
     {
         let build = Build::new(&self.phony, outputs);
         BuildRef(self.add_stmt(Stmt::Build(Box::new(build))))
@@ -139,7 +139,7 @@ impl Ninja {
     pub fn variable<SName, SValue>(&self, name: SName, value: SValue) -> &Self
     where
         SName: AsRef<str>,
-        SValue: AsRef<str>,
+        SValue: AsRef<MaybeOs!(str)>,
     {
         self.stmts
             .add_rc(Stmt::Variable(Variable::new(name, value)));
@@ -166,7 +166,7 @@ impl Ninja {
     pub fn defaults<SOutputIter, SOutput>(&self, outputs: SOutputIter) -> &Self
     where
         SOutputIter: IntoIterator<Item = SOutput>,
-        SOutput: AsRef<str>,
+        SOutput: AsRef<MaybeOs!(str)>,
     {
         self.stmts.add_rc(Stmt::Default(
             outputs.into_iter().map(|s| s.as_ref().to_owned()).collect(),
@@ -190,7 +190,7 @@ impl Ninja {
     /// ```
     pub fn subninja<SPath>(&self, path: SPath) -> &Self
     where
-        SPath: AsRef<str>,
+        SPath: AsRef<MaybeOs!(str)>,
     {
         self.stmts.add_rc(Stmt::Subninja(path.as_ref().to_owned()));
         self
@@ -217,7 +217,7 @@ impl Ninja {
     /// ```
     pub fn include<SPath>(&self, path: SPath) -> &Self
     where
-        SPath: AsRef<str>,
+        SPath: AsRef<MaybeOs!(str)>,
     {
         self.stmts.add_rc(Stmt::Include(path.as_ref().to_owned()));
         self
@@ -260,12 +260,12 @@ impl Display for Ninja {
                 Stmt::Default(outputs) => {
                     write!(f, "default")?;
                     for output in outputs {
-                        write!(f, " {}", output)?;
+                        write!(f, " {}", MaybeOsDisplay!(output))?;
                     }
                     writeln!(f)?;
                 }
-                Stmt::Subninja(path) => writeln!(f, "subninja {}", path)?,
-                Stmt::Include(path) => writeln!(f, "include {}", path)?,
+                Stmt::Subninja(path) => writeln!(f, "subninja {}", MaybeOsDisplay!(path))?,
+                Stmt::Include(path) => writeln!(f, "include {}", MaybeOsDisplay!(path))?,
             }
         }
         Ok(())

--- a/src/rule.rs
+++ b/src/rule.rs
@@ -8,7 +8,7 @@ use core::ops::Deref;
 
 use crate::stmt::{Stmt, StmtRef};
 use crate::util::{AddOnlyVec, Indented, RefCounted};
-use crate::{Build, BuildRef, Ninja, Pool, Variable, Variables};
+use crate::{Build, BuildRef, MaybeOs, Ninja, Pool, Variable, Variables};
 
 /// A rule, as defined by the `rule` keyword
 ///
@@ -147,7 +147,7 @@ pub trait RuleVariables: Variables {
     #[inline]
     fn depfile<SDepfile>(self, depfile: SDepfile) -> Self
     where
-        SDepfile: AsRef<str>,
+        SDepfile: AsRef<MaybeOs!(str)>,
     {
         self.variable("depfile", depfile)
     }
@@ -191,7 +191,7 @@ pub trait RuleVariables: Variables {
     /// ```
     fn deps_msvc_prefix<SMsvcDepsPrefix>(self, msvc_deps_prefix: SMsvcDepsPrefix) -> Self
     where
-        SMsvcDepsPrefix: AsRef<str>,
+        SMsvcDepsPrefix: AsRef<MaybeOs!(str)>,
     {
         self.deps_msvc()
             .variable("msvc_deps_prefix", msvc_deps_prefix)
@@ -239,7 +239,7 @@ pub trait RuleVariables: Variables {
     where
         SDesc: AsRef<str>,
     {
-        self.variable("description", desc)
+        self.variable("description", MaybeOs!(&desc))
     }
 
     /// Indicate the rule is used to re-invoke the generator
@@ -288,7 +288,7 @@ pub trait RuleVariables: Variables {
     #[inline]
     fn in_newline<SIn>(self, in_newline: SIn) -> Self
     where
-        SIn: AsRef<str>,
+        SIn: AsRef<MaybeOs!(str)>,
     {
         self.variable("in_newline", in_newline)
     }
@@ -336,11 +336,11 @@ pub trait RuleVariables: Variables {
         rspfile_content: SRspfileContent,
     ) -> Self
     where
-        SRspfile: AsRef<str>,
+        SRspfile: AsRef<MaybeOs!(str)>,
         SRspfileContent: AsRef<str>,
     {
         self.variable("rspfile", rspfile)
-            .variable("rspfile_content", rspfile_content)
+            .variable("rspfile_content", MaybeOs!(&rspfile_content))
     }
 
     /// Set `pool = console` for this `rule` or `build`
@@ -425,7 +425,7 @@ impl RuleRef {
     pub fn build<SOutputIter, SOutput>(&self, outputs: SOutputIter) -> BuildRef
     where
         SOutputIter: IntoIterator<Item = SOutput>,
-        SOutput: AsRef<str>,
+        SOutput: AsRef<MaybeOs!(str)>,
     {
         let build = Build::new(self.deref(), outputs);
         BuildRef(self.0.add(Stmt::Build(Box::new(build))))
@@ -443,7 +443,7 @@ impl Rule {
             name: RefCounted::new(name.as_ref().to_owned()),
             variables: AddOnlyVec::new(),
         };
-        s.variable("command", command)
+        s.variable("command", MaybeOs!(&command))
     }
 
     /// Add the rule to a ninja file and return a [`RuleRef`] for further configuration

--- a/src/stmt.rs
+++ b/src/stmt.rs
@@ -6,7 +6,7 @@ use alloc::vec::Vec;
 use core::ops::Deref;
 
 use crate::util::{AddOnlyVec, RefCounted};
-use crate::{Build, Pool, Rule, Variable};
+use crate::{Build, MaybeOs, Pool, Rule, Variable};
 
 /// A top-level ninja statement
 #[derive(Debug)]
@@ -32,16 +32,16 @@ pub enum Stmt {
     /// A default statement
     ///
     /// See <https://ninja-build.org/manual.html#_default_target_statements>
-    Default(Vec<String>),
+    Default(Vec<MaybeOs!(String)>),
     /// A subninja statement
     ///
     /// See <https://ninja-build.org/manual.html#ref_scope>
-    Subninja(String),
+    Subninja(MaybeOs!(String)),
 
     /// An include statement (like subninja, but doesn't create a new scope)
     ///
     /// See <https://ninja-build.org/manual.html#ref_scope>
-    Include(String),
+    Include(MaybeOs!(String)),
 
     /// A pool declaration
     ///

--- a/src/variable.rs
+++ b/src/variable.rs
@@ -1,5 +1,7 @@
 //! Implementation of variables
 
+use crate::{MaybeOs, MaybeOsDisplay};
+
 use alloc::borrow::ToOwned;
 use alloc::string::String;
 use core::fmt::{Display, Formatter, Result};
@@ -22,7 +24,7 @@ pub struct Variable {
     /// The name of the variable
     pub name: String,
     /// The value of the variable
-    pub value: String,
+    pub value: MaybeOs!(String),
 }
 
 impl Variable {
@@ -30,7 +32,7 @@ impl Variable {
     pub fn new<SName, SValue>(name: SName, value: SValue) -> Self
     where
         SName: AsRef<str>,
-        SValue: AsRef<str>,
+        SValue: AsRef<MaybeOs!(str)>,
     {
         Self {
             name: name.as_ref().to_owned(),
@@ -41,7 +43,7 @@ impl Variable {
 
 impl Display for Variable {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        write!(f, "{} = {}", self.name, self.value)
+        write!(f, "{} = {}", self.name, MaybeOsDisplay!(&self.value))
     }
 }
 
@@ -56,7 +58,7 @@ pub trait Variables: Sized {
     fn variable<SName, SValue>(self, name: SName, value: SValue) -> Self
     where
         SName: AsRef<str>,
-        SValue: AsRef<str>,
+        SValue: AsRef<MaybeOs!(str)>,
     {
         self.add_variable_internal(Variable::new(name, value));
         self


### PR DESCRIPTION
This PR adds a new feature to the crate, `os-string`. When this feature is activated, functions in the crate that (could) accept a path with a type of `AsRef<str>`, switch their parameter types to `AsRef<OsStr>`. With this feature, the crate is much more ergonomic when using the `PathBuf` type, which is really useful when creating meta-build-systems.

This PR is still a WIP, awaiting some feedback on whether there is interest in merging such a feature.

Tasks:
- [x] Implementation of the feature
- [x] Current tests passing
- [ ] New tests
- [ ] Documentation

Some open questions:
- [ ] Should this feature be active by default / merged with `std`?
- [ ] Currently, the `OsString`s are being lossly converted to `String`s when needed. This means that build scripts could be generated with incorrect paths (though this should rarely be the case). An alternative could be to do lossless conversions and panic when unable to convert, or to provide an alternative to the `Display` trait for build script generation, returning a byte stream instead of a `String`. Where should we head?
- [ ] Should the macros be renamed / moved / made public?